### PR TITLE
✨ Added a delete action button next to the reply button on a thread

### DIFF
--- a/pages/threads/threads.pixy
+++ b/pages/threads/threads.pixy
@@ -21,3 +21,8 @@ component Thread(thread *arn.Thread, posts []*arn.Post, user *arn.User)
 					button.action(data-action="forumReply", data-trigger="click")
 						Icon("mail-reply")
 						span Reply
+					if user.Role == "admin" || user.Role == "editor"
+						button.action(data-action="deleteObject", data-trigger="click", data-return-path="/forum", data-confirm-type="thread", data-api="/api/thread/" + thread.ID)
+							Icon("trash")
+							span Delete	
+						


### PR DESCRIPTION
This button is accessible only to connected users and members of the staff. As for the post deletion, this action requires validating the choice of deleting a thread to avoid removing a thread by mistake.

After deleting a thread, we redirect the user to the forum.

Here the UI changes:
* Light theme
  * Before: ![image](https://user-images.githubusercontent.com/11772084/33232561-a78d2a96-d208-11e7-96ea-ac3ca849f16c.png)
  * After ![image](https://user-images.githubusercontent.com/11772084/33232626-a67d5cd8-d209-11e7-9b5f-e1dc2a5af13b.png)

* Dark theme
  * Before ![image](https://user-images.githubusercontent.com/11772084/33232569-c16b7026-d208-11e7-9223-06f1184c2f7d.png)
  * After ![image](https://user-images.githubusercontent.com/11772084/33232619-94a34b08-d209-11e7-882d-480458383ad3.png)


Close #44 