### PR TITLE
🐛 The explore page will now display the anime from the current year.

### DIFF
--- a/pages/explore/explore.go
+++ b/pages/explore/explore.go
@@ -5,11 +5,13 @@ import (
 	"github.com/animenotifier/arn"
 	"github.com/animenotifier/notify.moe/components"
 	"github.com/animenotifier/notify.moe/utils"
+	"time"
+	"strconv"
 )
 
 // Get ...
 func Get(ctx *aero.Context) string {
-	year := "2017"
+	year := strconv.Itoa(time.Now().Year())
 	status := "current"
 	typ := "tv"
 	results := filterAnime(year, status, typ)


### PR DESCRIPTION
Currently, the explore page display the anime of the year 2017 just like in the following image
![image](https://user-images.githubusercontent.com/11772084/35474292-76c7dbee-038c-11e8-8d17-fadb090d8295.png)

The problem is that we currently are in 2018, this pull request fixes the issue and the explore page will now display the anime of the current year instead of a designated one like 2017.