### PR TITLE
🐛 Reduce the noise in the calendar

### DIFF
--- a/pages/calendar/calendar.go
+++ b/pages/calendar/calendar.go
@@ -50,6 +50,10 @@ func Get(ctx *aero.Context) string {
 
 	// Add anime episodes to the days
 	for animeEpisodes := range arn.StreamAnimeEpisodes() {
+		if animeEpisodes.Anime().Status == "finished" {
+			continue
+		}
+
 		for _, episode := range animeEpisodes.Items {
 			if !validator.IsValidDate(episode.AiringDate.Start) {
 				continue


### PR DESCRIPTION
I think that there is a lot of noise on the calendar page
![image](https://user-images.githubusercontent.com/11772084/35474720-7910e502-0392-11e8-8071-9b83db34bc96.png)

The noise is created by anime that are already finished, linked with shoboi and reaired on Japanese TV like [Nono-chan](https://notify.moe/anime/4638) which is displayed every day, an anime aiming for children and currently is in a planned list of 1 person on the website.

The fix I propose is to filter on the calendar the anime that are finished.