### PR TITLE
💄 Hide Edition tab to Logged out users

### DIFF
--- a/pages/company/company.pixy
+++ b/pages/company/company.pixy
@@ -48,5 +48,6 @@ component CompanyAnime(label string, animes []*arn.Anime, user *arn.User)
 component CompanyTabs(company *arn.Company, user *arn.User)
 	.tabs
 		Tab("Company", "building", company.Link())
-		Tab("Edit", "pencil", company.Link() + "/edit")
+		if user != nil
+			Tab("Edit", "pencil", company.Link() + "/edit")
 		Tab("History", "history", company.Link() + "/history")

--- a/pages/quote/quote.pixy
+++ b/pages/quote/quote.pixy
@@ -52,7 +52,8 @@ component QuoteTabs(quote *arn.Quote, user *arn.User)
 	.tabs
 		TabLike(strconv.Itoa(len(quote.Likes)), "heart", "quote", quote, user)
 		Tab("Quote", "quote-left", quote.Link())
-		Tab("Edit", "pencil", quote.Link() + "/edit")
+		if user != nil
+			Tab("Edit", "pencil", quote.Link() + "/edit")
 		Tab("History", "history", quote.Link() + "/history")
 
 component QuoteAnime(anime *arn.Anime, user *arn.User)

--- a/pages/soundtrack/soundtrack.pixy
+++ b/pages/soundtrack/soundtrack.pixy
@@ -66,5 +66,6 @@ component SoundTrackTabs(track *arn.SoundTrack, user *arn.User)
 	.tabs
 		TabLike(strconv.Itoa(len(track.Likes)), "heart", "track", track, user)
 		Tab("Soundtrack", "music", track.Link())
-		Tab("Edit", "pencil", track.Link() + "/edit")
+		if user != nil
+			Tab("Edit", "pencil", track.Link() + "/edit")
 		Tab("History", "history", track.Link() + "/history")


### PR DESCRIPTION
Hide the edition tabs to logged out users.
Hiding them to logged out users is logical since when they are logged out they cannot edit, and there is no point to show the whole edition page whereas any change they will made will prompt an error.