### PR TITLE
Main quote and minimal boolean type for EditForm

### DIFF
--- a/pages/character/character.go
+++ b/pages/character/character.go
@@ -37,7 +37,14 @@ func Get(ctx *aero.Context) string {
 	})
 
 	// Quotes
+	var mainQuote *arn.Quote
 	quotes := character.Quotes()
+	for i, quote := range quotes {
+		if quote.IsMainQuote {
+			mainQuote = quote
+			quotes = append(quotes[:i], quotes[i+1:]...)
+		}
+	}
 	arn.SortQuotesPopularFirst(quotes)
 
 	// Set OpenGraph attributes
@@ -65,5 +72,5 @@ func Get(ctx *aero.Context) string {
 		},
 	}
 
-	return ctx.HTML(components.CharacterDetails(character, characterAnime, quotes, user))
+	return ctx.HTML(components.CharacterDetails(character, characterAnime, quotes, mainQuote, user))
 }

--- a/pages/character/character.pixy
+++ b/pages/character/character.pixy
@@ -14,7 +14,7 @@ component CharacterDetails(character *arn.Character, characterAnime []*arn.Anime
 						else
 							Japanese("日本語の名前無し")
 					if mainQuote != nil	
-						.character-main-quote
+						.character-quote
 							Quote(mainQuote)
 					.character-description.mountable!= markdown.Render(character.Description)
 			

--- a/pages/character/character.pixy
+++ b/pages/character/character.pixy
@@ -1,4 +1,4 @@
-component CharacterDetails(character *arn.Character, characterAnime []*arn.Anime, quotes []*arn.Quote, user *arn.User)
+component CharacterDetails(character *arn.Character, characterAnime []*arn.Anime, quotes []*arn.Quote, mainQuote *arn.Quote, user *arn.User)
 	.character-page
 		.character-left-column
 			.character-header
@@ -13,7 +13,9 @@ component CharacterDetails(character *arn.Character, characterAnime []*arn.Anime
 							Japanese(character.Name.Japanese)
 						else
 							Japanese("日本語の名前無し")
-					
+					if mainQuote != nil	
+						.character-main-quote
+							Quote(mainQuote)
 					.character-description.mountable!= markdown.Render(character.Description)
 			
 					h3.mountable Anime

--- a/pages/character/character.scarlet
+++ b/pages/character/character.scarlet
@@ -45,7 +45,8 @@
 .character-quotes
 	vertical
 
-.character-quote
+.character-quote,
+.character-main-quote
 	footer,
 	.quote-footer
 		display none

--- a/pages/character/character.scarlet
+++ b/pages/character/character.scarlet
@@ -45,8 +45,7 @@
 .character-quotes
 	vertical
 
-.character-quote,
-.character-main-quote
+.character-quote
 	footer,
 	.quote-footer
 		display none

--- a/utils/editform/editform.go
+++ b/utils/editform/editform.go
@@ -201,6 +201,7 @@ func RenderField(b *bytes.Buffer, v *reflect.Value, field reflect.StructField, i
 		}
 
 		// TODO: Render bool type
+		b.WriteString(components.InputBool(idPrefix+field.Name, fieldValue.Bool(), field.Name, field.Tag.Get("tooltip")))
 		return
 	}
 


### PR DESCRIPTION
Add the possibility for editors to mark a quote as a main quote for a character.

The main quote is then displayed above the character description.