### PR TITLE
Display latest anime trailer on an anime page.

### DIFF
--- a/pages/anime/anime.pixy
+++ b/pages/anime/anime.pixy
@@ -150,11 +150,14 @@ component AnimeGenres(anime *arn.Anime)
 				span= genre
 
 component AnimeTrailer(anime *arn.Anime)
-	if len(anime.Trailers) > 0 && anime.Trailers[0].Service == "Youtube" && anime.Trailers[0].ServiceID != ""
-		section.anime-section.mountable
-			h3.anime-section-name Trailer
-			.anime-trailer.video-container
-				iframe.video(src="https://www.youtube.com/embed/" + anime.Trailers[0].ServiceID + "?showinfo=0", allowfullscreen="allowfullscreen")
+	if len(anime.Trailers) > 0 && anime.Trailers[len(anime.Trailers) - 1].Service == "Youtube" && anime.Trailers[len(anime.Trailers) - 1].ServiceID != ""
+		AnimeTrailerByIndex(anime, len(anime.Trailers)-1)
+
+component AnimeTrailerByIndex(anime *arn.Anime, index int)
+	section.anime-section.mountable
+		h3.anime-section-name Trailer
+		.anime-trailer.video-container
+			iframe.video(src="https://www.youtube.com/embed/" + anime.Trailers[index].ServiceID + "?showinfo=0", allowfullscreen="allowfullscreen")
 
 component AnimeFriends(friends []*arn.User, listItems map[*arn.User]*arn.AnimeListItem)
 	if len(friends) > 0


### PR DESCRIPTION
Display the last trailer instead of the first one on a anime page
The reason for this change is that I try to add every new trailer that is airing but since only the first one is displayed we can't really see the latest one on the anime page.