### PR TITLE
Music play speed controls not working

### DIFF
--- a/scripts/AnimeNotifier.ts
+++ b/scripts/AnimeNotifier.ts
@@ -1054,14 +1054,15 @@ export default class AnimeNotifier {
 			return preventDefault()
 		}
 
+
 		// "+" = Audio speed up
-		if(e.keyCode === 107 || e.keyCode === 187) {
+		if(e.keyCode === 107 || e.keyCode === 187 || e.key == "+") {
 			this.audioPlayer.addSpeed(0.05)
 			return preventDefault()
 		}
 
 		// "-" = Audio speed down
-		if(e.keyCode === 109 || e.keyCode === 189) {
+		if(e.keyCode === 109 || e.keyCode === 189 || e.key == "-") {
 			this.audioPlayer.addSpeed(-0.05)
 			return preventDefault()
 		}


### PR DESCRIPTION
At last on Scandinavian keyboard layout. 
So put general "-" "+" controls, should work basically on every keyboard. 
Minus key = 173
Plus key = 171
You want to use them. 