### PR TITLE
Persistent hide #123

### DIFF
--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -41,7 +41,6 @@ export function hideAddedAnime(arn?: AnimeNotifier, input?: HTMLInputElement) {
 			}
 		}
 	}
-
 }
 
 // Hides anime that are not in your list.

--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -26,15 +26,16 @@ export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
 }
 
 // Hides anime that are already in your list. And "toggles" localStorage.hide if button is pressed
-export function hideAddedAnime(arn?: AnimeNotifier, input?: HTMLInputElement) {
-	if (input != undefined && input.type == "submit") {
-		if(localStorage.hide === "true")
-			localStorage.hide = "false"
-		else
-			localStorage.hide = "true"
+export function hideAddedAnime(arn?: AnimeNotifier, input?: HTMLButtonElement) {
+	if(input) {
+		if(localStorage.getItem("hideAdded") === "true") {
+			localStorage.setItem("hideAdded", "false")
+		} else {
+			localStorage.setItem("hideAdded", "true")
+		}
 	}
 
-	if(localStorage.hide === "true" || input.type === "submit"){
+	if(localStorage.getItem("hideAdded") === "true" || input.type === "submit") {
 		for(let anime of findAll("anime-grid-cell")) {
 			if(anime.dataset.added === "true") {
 				anime.classList.toggle("anime-grid-cell-hide")

--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -28,14 +28,14 @@ export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
 // Hides anime that are already in your list. And "toggles" localStorage.hide if button is pressed
 export function hideAddedAnime(arn?: AnimeNotifier, input?: HTMLButtonElement) {
 	if(input) {
-		if(localStorage.getItem("hideAdded") === "true") {
-			localStorage.setItem("hideAdded", "false")
+		if(localStorage.getItem("hide-added-anime") === "true") {
+			localStorage.setItem("hide-added-anime", "false")
 		} else {
-			localStorage.setItem("hideAdded", "true")
+			localStorage.setItem("hide-added-anime", "true")
 		}
 	}
 
-	if(localStorage.getItem("hideAdded") === "true" || input.type === "submit") {
+	if(input || localStorage.getItem("hide-added-anime") === "true") {
 		for(let anime of findAll("anime-grid-cell")) {
 			if(anime.dataset.added === "true") {
 				anime.classList.toggle("anime-grid-cell-hide")

--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -25,13 +25,23 @@ export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
 	arn.diff(`${root.dataset.url}/${year}/${season}/${status}/${type}`)
 }
 
-// Hides anime that are already in your list.
-export function hideAddedAnime() {
-	for(let anime of findAll("anime-grid-cell")) {
-		if(anime.dataset.added === "true") {
-			anime.classList.toggle("anime-grid-cell-hide")
+// Hides anime that are already in your list. And "toggles" localStorage.hide if button is pressed
+export function hideAddedAnime(arn?: AnimeNotifier, input?: HTMLInputElement) {
+	if (input != undefined && input.type == "submit") {
+		if(localStorage.hide === "true")
+			localStorage.hide = "false"
+		else
+			localStorage.hide = "true"
+	}
+
+	if(localStorage.hide === "true" || input.type === "submit"){
+		for(let anime of findAll("anime-grid-cell")) {
+			if(anime.dataset.added === "true") {
+				anime.classList.toggle("anime-grid-cell-hide")
+			}
 		}
 	}
+
 }
 
 // Hides anime that are not in your list.

--- a/scripts/AnimeNotifier.ts
+++ b/scripts/AnimeNotifier.ts
@@ -480,7 +480,7 @@ export default class AnimeNotifier {
 			return
 		}
 
-		if(localStorage.getItem("hideAdded") === "true") {
+		if(localStorage.getItem("hide-added-anime") === "true") {
 			actions.hideAddedAnime()
 		}
 	}

--- a/scripts/AnimeNotifier.ts
+++ b/scripts/AnimeNotifier.ts
@@ -13,6 +13,7 @@ import { displayAiringDate, displayDate, displayTime } from "./DateView"
 import { findAll, canUseWebP, requestIdleCallback, swapElements, delay } from "./Utils"
 import { checkNewVersionDelayed } from "./NewVersionCheck"
 import * as actions from "./Actions"
+import { hideAddedAnime } from "./Actions";
 
 export default class AnimeNotifier {
 	app: Application
@@ -164,7 +165,8 @@ export default class AnimeNotifier {
 			Promise.resolve().then(() => this.dragAndDrop()),
 			Promise.resolve().then(() => this.colorStripes()),
 			Promise.resolve().then(() => this.assignTooltipOffsets()),
-			Promise.resolve().then(() => this.countUp())
+			Promise.resolve().then(() => this.countUp()),
+			Promise.resolve().then(() => this.hideMyAnimeInExplorer())
 		])
 
 		// Apply page title
@@ -470,6 +472,17 @@ export default class AnimeNotifier {
 			}
 
 			window.requestAnimationFrame(callback)
+		}
+	}
+
+	hideMyAnimeInExplorer() {
+		if(!this.app.currentPath.includes("/explore")){
+			return
+		}
+
+		const storage = localStorage.getItem("hide")
+		if(storage === "true"){
+			hideAddedAnime()
 		}
 	}
 

--- a/scripts/AnimeNotifier.ts
+++ b/scripts/AnimeNotifier.ts
@@ -475,6 +475,7 @@ export default class AnimeNotifier {
 		}
 	}
 
+	// Hides user anime automatically if localStorage.hide is true
 	hideMyAnimeInExplorer() {
 		if(!this.app.currentPath.includes("/explore")){
 			return

--- a/scripts/AnimeNotifier.ts
+++ b/scripts/AnimeNotifier.ts
@@ -13,7 +13,6 @@ import { displayAiringDate, displayDate, displayTime } from "./DateView"
 import { findAll, canUseWebP, requestIdleCallback, swapElements, delay } from "./Utils"
 import { checkNewVersionDelayed } from "./NewVersionCheck"
 import * as actions from "./Actions"
-import { hideAddedAnime } from "./Actions";
 
 export default class AnimeNotifier {
 	app: Application
@@ -166,7 +165,7 @@ export default class AnimeNotifier {
 			Promise.resolve().then(() => this.colorStripes()),
 			Promise.resolve().then(() => this.assignTooltipOffsets()),
 			Promise.resolve().then(() => this.countUp()),
-			Promise.resolve().then(() => this.hideMyAnimeInExplorer())
+			Promise.resolve().then(() => this.hideAddedAnime())
 		])
 
 		// Apply page title
@@ -476,14 +475,13 @@ export default class AnimeNotifier {
 	}
 
 	// Hides user anime automatically if localStorage.hide is true
-	hideMyAnimeInExplorer() {
-		if(!this.app.currentPath.includes("/explore")){
+	hideAddedAnime() {
+		if(!this.app.currentPath.includes("/explore") && !this.app.currentPath.includes("/genre")) {
 			return
 		}
 
-		const storage = localStorage.getItem("hide")
-		if(storage === "true"){
-			hideAddedAnime()
+		if(localStorage.getItem("hideAdded") === "true") {
+			actions.hideAddedAnime()
 		}
 	}
 


### PR DESCRIPTION
Fix for "hide collection" bug.
It saves it to `localStorage.hide` and reads from there if "filters" are changed. Should work now permanently even if user refreshes changes pages or comes back later.