### PR TITLE
UI for Genre: Average Rating and Total Completed Anime

### DIFF
--- a/pages/genre/genre.go
+++ b/pages/genre/genre.go
@@ -10,6 +10,7 @@ import (
 )
 
 const animePerPage = 100
+const animeRatingThreshold = 5
 
 // Get ...
 func Get(ctx *aero.Context) string {
@@ -23,8 +24,9 @@ func Get(ctx *aero.Context) string {
 		}
 	}
 
-	userScore := averageScore(user, animes)
+	userScore := averageUserScore(user, animes)
 	userCompleted := totalCompleted(user, animes)
+	globalScore := averageGlobalScore(animes)
 
 	arn.SortAnimeByQuality(animes)
 
@@ -32,7 +34,7 @@ func Get(ctx *aero.Context) string {
 		animes = animes[:animePerPage]
 	}
 
-	return ctx.HTML(components.Genre(genreName, animes, user, userScore, userCompleted))
+	return ctx.HTML(components.Genre(genreName, animes, user, userScore, userCompleted, globalScore))
 }
 
 // containsLowerCase tells you whether the given element exists when all elements are lowercased.
@@ -46,8 +48,8 @@ func containsLowerCase(array []string, search string) bool {
 	return false
 }
 
-// averageScore counts the user's average score for the given animes.
-func averageScore(user *arn.User, animes []*arn.Anime) float64 {
+// averageUserScore counts the user's average score for the given animes.
+func averageUserScore(user *arn.User, animes []*arn.Anime) float64 {
 	if user == nil {
 		return 0
 	}
@@ -71,6 +73,21 @@ func averageScore(user *arn.User, animes []*arn.Anime) float64 {
 	}
 
 	return scores / count
+}
+
+// averageGlobalScore returns the average overall score for the given anime
+func averageGlobalScore(animes []*arn.Anime) float64 {
+	sum := 0.0
+	count := 0
+
+	for _, anime := range animes {
+		if anime.Rating.Count.Overall >= animeRatingThreshold {
+			sum += anime.Rating.Overall
+			count++
+		}
+	}
+
+	return sum / float64(count)
 }
 
 // totalCompleted counts the number of animes the user has completed from a given list of anime

--- a/pages/genre/genre.go
+++ b/pages/genre/genre.go
@@ -24,6 +24,7 @@ func Get(ctx *aero.Context) string {
 	}
 
 	userScore := averageScore(user, animes)
+	userCompleted := totalCompleted(user, animes)
 
 	arn.SortAnimeByQuality(animes)
 
@@ -31,7 +32,7 @@ func Get(ctx *aero.Context) string {
 		animes = animes[:animePerPage]
 	}
 
-	return ctx.HTML(components.Genre(genreName, animes, user, userScore))
+	return ctx.HTML(components.Genre(genreName, animes, user, userScore, userCompleted))
 }
 
 // containsLowerCase tells you whether the given element exists when all elements are lowercased.
@@ -70,4 +71,25 @@ func averageScore(user *arn.User, animes []*arn.Anime) float64 {
 	}
 
 	return scores / count
+}
+
+// totalCompleted counts the number of animes the user has completed from a given list of anime
+func totalCompleted(user *arn.User, animes []*arn.Anime) int {
+	if user == nil {
+		return 0
+	}
+
+	count := 0
+
+	completedList := user.AnimeList().FilterStatus(arn.AnimeListStatusCompleted)
+
+	for _, anime := range animes {
+		userAnime := completedList.Find(anime.ID)
+
+		if userAnime != nil {
+			count++;
+		}
+	}
+
+	return count;
 }

--- a/pages/genre/genre.go
+++ b/pages/genre/genre.go
@@ -84,12 +84,10 @@ func totalCompleted(user *arn.User, animes []*arn.Anime) int {
 	completedList := user.AnimeList().FilterStatus(arn.AnimeListStatusCompleted)
 
 	for _, anime := range animes {
-		userAnime := completedList.Find(anime.ID)
-
-		if userAnime != nil {
-			count++;
+		if completedList.Contains(anime.ID) {
+			count++
 		}
 	}
 
-	return count;
+	return count
 }

--- a/pages/genre/genre.pixy
+++ b/pages/genre/genre.pixy
@@ -1,9 +1,7 @@
 component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64, userCompleted int)
 	h1(title=fmt.Sprint(len(animes)) + " anime")= strings.Title(genre)
 
-	if user != nil
-		.average-score-total-completed
-			p= fmt.Sprintf("Average rating: %." + strconv.Itoa(user.Settings().Format.RatingsPrecision) + "f | Total completed: %d", userScore, userCompleted)
+	GenreStatistics(user, userScore, userCompleted)
 	
 	.corner-buttons-hide-on-mobile
 		if user != nil
@@ -14,3 +12,8 @@ component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore flo
 			RawIcon("clone")
 
 	AnimeGrid(animes, user)
+
+component GenreStatistics(user *arn.User, userScore float64, userCompleted int)
+	if user != nil
+		.average-score-total-completed
+			p= fmt.Sprintf("Average rating: %." + strconv.Itoa(user.Settings().Format.RatingsPrecision) + "f | Total completed: %d", userScore, userCompleted)

--- a/pages/genre/genre.pixy
+++ b/pages/genre/genre.pixy
@@ -1,7 +1,7 @@
-component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64, userCompleted int)
+component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64, userCompleted int, globalScore float64)
 	h1(title=fmt.Sprint(len(animes)) + " anime")= strings.Title(genre)
 
-	GenreStatistics(user, userScore, userCompleted)
+	GenreStatistics(user, userScore, userCompleted, globalScore)
 	
 	.corner-buttons-hide-on-mobile
 		if user != nil
@@ -13,7 +13,7 @@ component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore flo
 
 	AnimeGrid(animes, user)
 
-component GenreStatistics(user *arn.User, userScore float64, userCompleted int)
+component GenreStatistics(user *arn.User, userScore float64, userCompleted int, globalScore float64)
 	if user != nil
 		.average-score-total-completed
 			p= fmt.Sprintf("Average rating: %." + strconv.Itoa(user.Settings().Format.RatingsPrecision) + "f | Total completed: %d", userScore, userCompleted)

--- a/pages/genre/genre.pixy
+++ b/pages/genre/genre.pixy
@@ -1,9 +1,9 @@
 component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64, userCompleted int)
 	h1(title=fmt.Sprint(len(animes)) + " anime")= strings.Title(genre)
 
-	.average-score-total-completed
-		if user != nil
-			p= fmt.Sprintf("Average Score: %.1f | Total Completed: %d", userScore, userCompleted)
+	if user != nil
+		.average-score-total-completed
+			p= fmt.Sprintf("Average rating: %." + strconv.Itoa(user.Settings().Format.RatingsPrecision) + "f | Total completed: %d", userScore, userCompleted)
 	
 	.corner-buttons-hide-on-mobile
 		if user != nil

--- a/pages/genre/genre.pixy
+++ b/pages/genre/genre.pixy
@@ -1,9 +1,9 @@
-component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64)
+component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64, userCompleted int)
 	h1(title=fmt.Sprint(len(animes)) + " anime")= strings.Title(genre)
 
-	.average-score
+	.average-score-total-completed
 		if user != nil
-			p= fmt.Sprintf("Average Score: %.1f", userScore)
+			p= fmt.Sprintf("Average Score: %.1f | Total Completed: %d", userScore, userCompleted)
 	
 	.corner-buttons-hide-on-mobile
 		if user != nil

--- a/pages/genre/genre.pixy
+++ b/pages/genre/genre.pixy
@@ -1,8 +1,9 @@
 component Genre(genre string, animes []*arn.Anime, user *arn.User, userScore float64)
 	h1(title=fmt.Sprint(len(animes)) + " anime")= strings.Title(genre)
 
-	//- if user != nil
-	//- 	h2= fmt.Sprintf("%.1f", userScore)
+	.average-score
+		if user != nil
+			p= fmt.Sprintf("Average Score: %.1f", userScore)
 	
 	.corner-buttons-hide-on-mobile
 		if user != nil

--- a/pages/genre/genre.scarlet
+++ b/pages/genre/genre.scarlet
@@ -1,2 +1,3 @@
-.average-score
+.average-score-total-completed
 	text-align center
+	font-size 1.25em

--- a/pages/genre/genre.scarlet
+++ b/pages/genre/genre.scarlet
@@ -1,0 +1,2 @@
+.average-score
+	text-align center


### PR DESCRIPTION
Concerns issue #94 

I've implemented a basic UI that displays the average score and the total number of anime completed on each genre's page underneath the header. I also wrote a bit of simple functionality to get the total anime completed for a genre.

Let me know if you'd like any changes.