### PR TITLE
Added markdown formatting to a anime summary on a anime page

### DIFF
--- a/pages/anime/anime.pixy
+++ b/pages/anime/anime.pixy
@@ -18,7 +18,7 @@ component AnimeMainColumn(anime *arn.Anime, listItem *arn.AnimeListItem, tracks 
 			h2.anime-alternative-title.mountable(data-mountable-type="header")
 				Japanese(anime.Title.Japanese)
 
-			p.anime-summary.mountable(data-mountable-type="header")= anime.Summary
+			p.anime-summary.mountable(data-mountable-type="header")!= anime.HTML()
 
 			.anime-summary-footer-container
 				.anime-summary-footer


### PR DESCRIPTION
Currently, if the summary of an anime were long enough, it would look like a blob of text which was not easy to read.

Some of those [summaries](https://notify.moe/anime/yF1RhKiiR) already have the necessary line break to make them more readable, so I thought it would be useful to display them after being formatted by a markdown processor.

|Before|After|
|:----:|:---:|
|![](https://cdn.discordapp.com/attachments/330433484520685570/494502184289959956/unknown.png)|![](https://cdn.discordapp.com/attachments/330433484520685570/494502416364994560/unknown.png)|

Linked to https://github.com/animenotifier/arn/pull/14