### PR TITLE
Made the show/hide anime not in my list persistent

### DIFF
--- a/pages/calendar/calendar.pixy
+++ b/pages/calendar/calendar.pixy
@@ -4,10 +4,7 @@ component Calendar(days []*utils.CalendarDay, user *arn.User)
 	.corner-buttons
 		if user != nil
 			button.action(data-trigger="click", data-action="calendarShowAddedAnimeOnly", data-api="/api/settings/" + user.ID, title="Show anime in my collection")
-				RawIcon("eye")
-		else
-			button.action(data-trigger="click", data-action="calendarShowAddedAnimeOnly", title="Show anime in my collection")
-				RawIcon("eye")
+				RawIcon("eye-slash")
 
 	.week
 		each day in days
@@ -18,19 +15,17 @@ component Calendar(days []*utils.CalendarDay, user *arn.User)
 						CalendarEntry(day, entry, user)
 
 component CalendarEntry(day *utils.CalendarDay, entry *utils.CalendarEntry, user *arn.User)
-	if user!= nil && user.Settings().CalendarSettings.ShowUserList == true
-		a.calendar-entry.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
-			img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
-			.calendar-entry-info
-				.calendar-entry-title= entry.Anime.Title.ByUser(user)
-				.calendar-entry-time-and-episode
-					.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
-					.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)
-	else
+	if user != nil && user.Settings().CalendarSettings.ShowUserList == false && !entry.Added
 		a.calendar-entry.hidden.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
-			img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
-			.calendar-entry-info
-				.calendar-entry-title= entry.Anime.Title.ByUser(user)
-				.calendar-entry-time-and-episode
-					.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
-					.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)
+			CalendarView(day, entry, user)
+	else
+		a.calendar-entry.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
+			CalendarView(day, entry, user)
+
+component CalendarView(day *utils.CalendarDay, entry *utils.CalendarEntry, user *arn.User)
+	img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
+		.calendar-entry-info
+			.calendar-entry-title= entry.Anime.Title.ByUser(user)
+			.calendar-entry-time-and-episode
+				.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
+				.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)

--- a/pages/calendar/calendar.pixy
+++ b/pages/calendar/calendar.pixy
@@ -2,8 +2,12 @@ component Calendar(days []*utils.CalendarDay, user *arn.User)
 	h1.mountable Calendar
 
 	.corner-buttons
-		button.action(data-trigger="click", data-action="calendarShowAddedAnimeOnly", title="Show anime in my collection")
-			RawIcon("eye")
+		if user != nil
+			button.action(data-trigger="click", data-action="calendarShowAddedAnimeOnly", data-api="/api/settings/" + user.ID, title="Show anime in my collection")
+				RawIcon("eye")
+		else
+			button.action(data-trigger="click", data-action="calendarShowAddedAnimeOnly", title="Show anime in my collection")
+				RawIcon("eye")
 
 	.week
 		each day in days
@@ -11,10 +15,22 @@ component Calendar(days []*utils.CalendarDay, user *arn.User)
 				h3.weekday-name.mountable(data-mountable-type=day.Name)= day.Name
 				.calendar-entries
 					each entry in day.Entries
-						a.calendar-entry.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
-							img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
-							.calendar-entry-info
-								.calendar-entry-title= entry.Anime.Title.ByUser(user)
-								.calendar-entry-time-and-episode
-									.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
-									.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)
+						CalendarEntry(day, entry, user)
+
+component CalendarEntry(day *utils.CalendarDay, entry *utils.CalendarEntry, user *arn.User)
+	if user!= nil && user.Settings().CalendarSettings.ShowUserList == true
+		a.calendar-entry.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
+			img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
+			.calendar-entry-info
+				.calendar-entry-title= entry.Anime.Title.ByUser(user)
+				.calendar-entry-time-and-episode
+					.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
+					.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)
+	else
+		a.calendar-entry.hidden.mountable(href=entry.Anime.Link(), data-mountable-type=day.Name, data-added=entry.Added)
+			img.calendar-entry-image.lazy(data-src=entry.Anime.ImageLink("small"), data-webp="true", data-color=entry.Anime.AverageColor(), alt=entry.Anime.Title.ByUser(user))
+			.calendar-entry-info
+				.calendar-entry-title= entry.Anime.Title.ByUser(user)
+				.calendar-entry-time-and-episode
+					.calendar-entry-time.utc-date-absolute(data-date=entry.Episode.AiringDate.Start)
+					.calendar-entry-episode= "Ep: " + strconv.Itoa(entry.Episode.Number)

--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -1,5 +1,5 @@
 import AnimeNotifier from "../AnimeNotifier"
-import {findAll} from "scripts/Utils"
+import { findAll } from "scripts/Utils"
 
 // Filter anime on explore page
 export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
@@ -10,7 +10,7 @@ export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
 	let elementStatus = document.getElementById("filter-status") as HTMLSelectElement
 	let elementType = document.getElementById("filter-type") as HTMLSelectElement
 
-	for (let element of findAll("anime-grid-image")) {
+	for(let element of findAll("anime-grid-image")) {
 		let img = element as HTMLImageElement
 		img.src = arn.emptyPixel()
 		img.classList.remove("element-found")
@@ -32,8 +32,8 @@ export function toggleHideAddedAnime() {
 
 // Hides anime that are already in your list.
 export function hideAddedAnime() {
-	for (let anime of findAll("anime-grid-cell")) {
-		if (anime.dataset.added !== "true") {
+	for(let anime of findAll("anime-grid-cell")) {
+		if(anime.dataset.added !== "true") {
 			continue
 		}
 
@@ -43,14 +43,14 @@ export function hideAddedAnime() {
 
 // Hides anime that are not in your list.
 export function calendarShowAddedAnimeOnly(arn: AnimeNotifier, element: HTMLInputElement) {
-	for (let anime of findAll("calendar-entry")) {
-		if (anime.dataset.added === "false") {
+	for(let anime of findAll("calendar-entry")) {
+		if(anime.dataset.added === "false") {
 			anime.classList.toggle("hidden")
 		}
 	}
 
-	const anime = document.getElementsByClassName("calendar-entry").item(0)
-	const showUserList = !anime.classList.contains("hidden")
+	const showUserList = !Array.from(document.getElementsByClassName("calendar-entry"))
+		.some(value => value.classList.contains("hidden"));
 
 	let obj = {
 		"CalendarSettings.ShowUserList": showUserList

--- a/scripts/Actions/Explore.ts
+++ b/scripts/Actions/Explore.ts
@@ -1,5 +1,5 @@
 import AnimeNotifier from "../AnimeNotifier"
-import { findAll } from "scripts/Utils"
+import {findAll} from "scripts/Utils"
 
 // Filter anime on explore page
 export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
@@ -10,7 +10,7 @@ export function filterAnime(arn: AnimeNotifier, input: HTMLInputElement) {
 	let elementStatus = document.getElementById("filter-status") as HTMLSelectElement
 	let elementType = document.getElementById("filter-type") as HTMLSelectElement
 
-	for(let element of findAll("anime-grid-image")) {
+	for (let element of findAll("anime-grid-image")) {
 		let img = element as HTMLImageElement
 		img.src = arn.emptyPixel()
 		img.classList.remove("element-found")
@@ -32,8 +32,8 @@ export function toggleHideAddedAnime() {
 
 // Hides anime that are already in your list.
 export function hideAddedAnime() {
-	for(let anime of findAll("anime-grid-cell")) {
-		if(anime.dataset.added !== "true") {
+	for (let anime of findAll("anime-grid-cell")) {
+		if (anime.dataset.added !== "true") {
 			continue
 		}
 
@@ -42,10 +42,21 @@ export function hideAddedAnime() {
 }
 
 // Hides anime that are not in your list.
-export function calendarShowAddedAnimeOnly() {
-	for(let anime of findAll("calendar-entry")) {
-		if(anime.dataset.added === "false") {
+export function calendarShowAddedAnimeOnly(arn: AnimeNotifier, element: HTMLInputElement) {
+	for (let anime of findAll("calendar-entry")) {
+		if (anime.dataset.added === "false") {
 			anime.classList.toggle("hidden")
 		}
 	}
+
+	const anime = document.getElementsByClassName("calendar-entry").item(0)
+	const showUserList = !anime.classList.contains("hidden")
+
+	let obj = {
+		"CalendarSettings.ShowUserList": showUserList
+	}
+
+	let apiEndpoint = arn.findAPIEndpoint(element);
+	arn.post(apiEndpoint, obj)
+		.catch(err => arn.statusMessage.showError(err));
 }


### PR DESCRIPTION
The PR propose a solution to #123, for the moment it only affect the calendar page, but it could be applied to other pages with the **"Hide collection"** option.

Some point could be improved, specifically the `calendar.pixy` file which I didn't know if there was a cleaner way to handle the case where we add the `hidden` class.

I made a video of this feature: https://youtu.be/xJIfhHHVcKE
