### PR TITLE
Make anime with only start month available visible in list filtered by seasons

### DIFF
--- a/arn/Anime.go
+++ b/arn/Anime.go
@@ -289,7 +289,7 @@ func (anime *Anime) AverageColor() string {
 
 // Season returns the season the anime started airing in.
 func (anime *Anime) Season() string {
-	if !validate.Date(anime.StartDate) {
+	if !validate.Date(anime.StartDate) && !validate.YearMonth(anime.StartDate) {
 		return ""
 	}
 

--- a/arn/validate/Validate.go
+++ b/arn/validate/Validate.go
@@ -13,6 +13,9 @@ const (
 	// DateFormat is the format used for short dates that don't include the time.
 	DateFormat = "2006-01-02"
 
+	// YearMonthFormat is the format used for validating dates that include the year and month.
+	YearMonthFormat = "2006-01"
+
 	// DateTimeFormat is the format used for long dates that include the time.
 	DateTimeFormat = time.RFC3339
 )
@@ -52,6 +55,16 @@ func Date(date string) bool {
 	}
 
 	_, err := time.Parse(DateFormat, date)
+	return err == nil
+}
+
+// YearMonth tells you whether the date contain only the year and the month.
+func YearMonth(date string) bool {
+	if date == "" || strings.HasPrefix(date, "0001") {
+		return false
+	}
+
+	_, err := time.Parse(YearMonthFormat, date)
 	return err == nil
 }
 


### PR DESCRIPTION
## 📢 Type of change
* [ ]  Bugfix
* [ ]  New feature
* [x]  Enhancement
* [ ]  Refactoring

## 📜 Description
This change allow an anime which have at least it's month set in it's airing date to be visible in any anime list filtered by seasons. 
It should make it easier for user to find what anime are coming for the next seasons and it'll be easier for editors to see which anime is missing in our database or is missing information when compared to other anie tracking websites.

## 💡 Motivation and Context
When an anime get announced we get which year it will be aired or even the month. In the later case we can deduce in which season this anime will be aired.
In the current state of notify.moe, we only show anime which have a exact airing date. this limitation makes it hard to find upcomings anime especially when this date is known really late.

## 💚 How did you test it?
 - Checked that an anime like [Beastars](https://notify.moe/anime/VTswx5eiR) which at the date of this PR, only have the year and the month specified in it's airing date is visible in the [/explore](https://beta.notify.moe/explore) page, the [editor page](https://beta.notify.moe/editor/anime/all/2019/autumn/any/tv) and not in the live version of [explore](https://notify.moe/explore) and [editor](https://notify.moe/editor/anime/all/2019/autumn/any/tv) pages.

## 📝 Checklist
* [x]  I compiled before submitting the PR
* [x]  I reviewed the submitted code

## 📸 Screenshots / GIFs
|Live version|PR version|
|---|----|
|![image](https://user-images.githubusercontent.com/11772084/64341093-ef423780-cfe7-11e9-87ce-d9a429224f3d.png)|![image](https://user-images.githubusercontent.com/11772084/64341046-d8034a00-cfe7-11e9-9b06-1de812021cbc.png)|